### PR TITLE
Demo integration with Event Driven Ansible

### DIFF
--- a/ruleops-basic/README.md
+++ b/ruleops-basic/README.md
@@ -54,6 +54,18 @@ alias ruleops="java -jar target/quarkus-app/quarkus-run.jar -Dquarkus.profile=cl
 ruleops
 ```
 
+### installing Event Driven Ansible collections etc. and invoking manually 
+
+```sh
+ansible-galaxy collection install ansible.eda
+ansible-galaxy collection install kubernetes.core
+pip3 install kubernetes
+ansible-rulebook --rulebook webhook-rulebook.yml -i inventory.yml --verbose
+curl -H 'Content-Type: application/json' -d "{\"provision\": \"PersistentVolume\", \"capacity\":\"3Gi\"}" http://127.0.0.1:5050/endpoint
+```
+
+
+
 <!--
 
 This project uses Quarkus, the Supersonic Subatomic Java Framework.

--- a/ruleops-basic/inventory.yml
+++ b/ruleops-basic/inventory.yml
@@ -1,0 +1,5 @@
+# for demo purposes
+all:
+  hosts:
+    localhost:
+      ansible_connection: local

--- a/ruleops-basic/provision-pv-playboook.yml
+++ b/ruleops-basic/provision-pv-playboook.yml
@@ -1,0 +1,23 @@
+- hosts: all
+  tasks:
+    - debug:
+        var: capacity
+    - name: create PV resource of the needed capacity 
+      kubernetes.core.k8s:
+        state: present
+        generate_name: edansible-pv-
+        definition:
+          apiVersion: v1
+          kind: PersistentVolume
+          metadata:
+            # see generate_name ... name: task-pv-volume
+            labels:
+              type: local
+          spec:
+            storageClassName: manual
+            capacity:
+              storage: '{{ capacity }}'
+            accessModes:
+              - ReadWriteOnce
+            hostPath:
+              path: "/tmp/minikubedata" # demo purposes

--- a/ruleops-basic/src/main/resources/application.properties
+++ b/ruleops-basic/src/main/resources/application.properties
@@ -6,6 +6,9 @@ quarkus.quinoa.dev-server.check-path=
 quarkus.quinoa.enable-spa-routing=true
 quarkus.quinoa.package-manager-command.install=npm install --force
 
+# remove the following property for local demo without EDAnsible listening.
+ruleops.edansible.endpoint=http://127.0.0.1:5050/endpoint
+
 %cli.quarkus.package.main-class=cli
 %cli.quarkus.log.level=WARN
 %cli.quarkus.banner.enabled=false

--- a/ruleops-basic/src/main/resources/application.properties
+++ b/ruleops-basic/src/main/resources/application.properties
@@ -7,7 +7,7 @@ quarkus.quinoa.enable-spa-routing=true
 quarkus.quinoa.package-manager-command.install=npm install --force
 
 # remove the following property for local demo without EDAnsible listening.
-ruleops.edansible.endpoint=http://127.0.0.1:5050/endpoint
+# ruleops.edansible.endpoint=http://127.0.0.1:5050/endpoint
 
 %cli.quarkus.package.main-class=cli
 %cli.quarkus.log.level=WARN

--- a/ruleops-basic/src/main/resources/rules/basic/rules.drl
+++ b/ruleops-basic/src/main/resources/rules/basic/rules.drl
@@ -5,6 +5,7 @@ import java.util.Map;
 import org.drools.ruleops.Utils;
 import org.drools.ruleops.DroolsUtils;
 import org.drools.ruleops.DroolsK8sClient;
+import org.drools.ruleops.EDAnsibleClient;
 import org.drools.ruleops.model.Advice;
 
 import io.fabric8.kubernetes.api.model.Container;
@@ -50,6 +51,7 @@ when
   Volume( persistentVolumeClaim!.claimName == $pvc.metadata.name ) from $pod.spec.volumes
 then
   insert(new Advice("Fix the PersistentVolume","Pod PENDING: "+$pod.getMetadata().getName() + " pvc PENDING: "+$pvc.getMetadata().getName()));
+  EDAnsibleClient.with("provision", "PersistentVolume").with("capacity", $pvc.getSpec().getResources().getRequests().get("storage")).sendEvent();
 end
 
 function boolean mapContains(Map left, Map right) {

--- a/ruleops-basic/src/main/resources/rules/basic/rules.drl.yaml
+++ b/ruleops-basic/src/main/resources/rules/basic/rules.drl.yaml
@@ -6,6 +6,7 @@ imports:
 - org.drools.ruleops.Utils
 - org.drools.ruleops.DroolsUtils
 - org.drools.ruleops.DroolsK8sClient
+- org.drools.ruleops.EDAnsibleClient
 - org.drools.ruleops.model.Advice
 - io.fabric8.kubernetes.api.model.Container
 - io.fabric8.kubernetes.api.model.ContainerPort
@@ -67,6 +68,7 @@ rules:
     from: $pod.spec.volumes
   then: |
     insert(new Advice("Fix the PersistentVolume","Pod PENDING: "+$pod.getMetadata().getName() + " pvc PENDING: "+$pvc.getMetadata().getName()));
+      EDAnsibleClient.with("provision", "PersistentVolume").with("capacity", $pvc.getSpec().getResources().getRequests().get("storage")).sendEvent();
 - name: Fix the Service selector No Pod found for selector
   when:
   - given: Service

--- a/ruleops-basic/webhook-rulebook.yml
+++ b/ruleops-basic/webhook-rulebook.yml
@@ -1,0 +1,14 @@
+- name: Listen for events on a webhook
+  hosts: all
+  sources:
+    - ansible.eda.webhook:
+        host: 0.0.0.0
+        port: 5050
+  rules:
+    - name: Provisioning the K8s resource
+      condition: event.payload.provision == "PersistentVolume"
+      action:
+        run_playbook:
+          name: provision-pv-playboook.yml
+          extra_vars:
+            capacity: '{{ event.payload.capacity }}'

--- a/ruleops-core/src/main/java/org/drools/ruleops/EDAnsibleClient.java
+++ b/ruleops-core/src/main/java/org/drools/ruleops/EDAnsibleClient.java
@@ -1,0 +1,69 @@
+package org.drools.ruleops;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class EDAnsibleClient {
+    private static final Logger LOG = LoggerFactory.getLogger(EDAnsibleClient.class);
+    private static long lastTsSent = 0;
+
+    private EDAnsibleClient() {
+        // only static utils.
+    }
+
+    public static EDAnsibleClientBuilder with(String key, Object value) {
+        return new EDAnsibleClientBuilder(key, value);
+    }
+
+    public static class EDAnsibleClientBuilder {
+        private URI edansibleURI;
+        private Map<String, Object> params = new HashMap<>();
+
+        EDAnsibleClientBuilder(String key, Object value) {
+            var endpoint = ConfigProvider.getConfig().getOptionalValue("ruleops.edansible.endpoint", String.class);
+            if (endpoint.isPresent()) {
+                edansibleURI = URI.create(endpoint.get());
+            }
+            params.put(key, value);
+        }
+
+        public EDAnsibleClientBuilder with(String key, Object value) {
+            params.put(key, value);
+            return this;
+        }
+
+        public void sendEvent() throws Exception {
+            if (edansibleURI == null) {
+                LOG.warn("ruleops.edansible.endpoint is not setup, won't notify EDAnsible.");
+                return;
+            }
+            long curTs = System.currentTimeMillis();
+            if (curTs - lastTsSent < 10_000) {
+                LOG.warn("TODO currently ruleops.edansible.endpoint supports sending max 1 event, every 10sec.");
+                return;
+            }
+            lastTsSent = curTs;
+            String requestBody = new ObjectMapper().writeValueAsString(params);
+            HttpClient client = HttpClient.newHttpClient();
+            HttpRequest request = HttpRequest.newBuilder()
+                    .version(Version.HTTP_1_1)
+                    .uri(edansibleURI)
+                    .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                    .build();
+            HttpResponse<String> response = client.send(request,
+                    HttpResponse.BodyHandlers.ofString());
+            LOG.info("{}", response);
+        }
+    }
+}


### PR DESCRIPTION
Resolves #19 

As documented here https://github.com/kiegroup/ruleops#extra-automate-it-with-event-driven-ansible

Demo in action:

step1
![Screenshot 2023-03-16 at 14 34 55](https://user-images.githubusercontent.com/1699252/227476414-7e681cad-8a86-438d-a1c1-8ed47f54e748.png)

step2
![Screenshot 2023-03-16 at 14 35 39](https://user-images.githubusercontent.com/1699252/227476487-f287aa3c-0d2a-4ac5-ab0d-3f726e6d7f87.png)

This demo is not "active" for E2E testing, hence the configuration to actually send the event via the EDAnsible webhook is intentionally disabled.